### PR TITLE
Site layout for docs uses wide 80% for large media

### DIFF
--- a/themes/template/assets/scss/_base.scss
+++ b/themes/template/assets/scss/_base.scss
@@ -27,7 +27,7 @@ body {
     }
     @include breakpoint(medium) {
     }
-    &.docs {
+    &.wide-content {
         @include breakpoint(extra-large) {
             max-width: 80%;
         }

--- a/themes/template/layouts/_default/docs.html
+++ b/themes/template/layouts/_default/docs.html
@@ -5,7 +5,7 @@
 				<h1>Documentation</h1>
 			</div>
 		</div>
-		<div class="wrapper docs clearfix">
+		<div class="wrapper docs wide-content clearfix">
 			{{ partial "docs-sidebar.html" . }}
 			<div class="docs-content {{ if not .Site.Params.docs_right_sidebar }}full{{ end }}">
 				{{ partial "version-warning.html" . }}

--- a/themes/template/layouts/partials/footer.html
+++ b/themes/template/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer>
-	<div class="wrapper footer-links">
+	<div {{ if (eq .Page.Section "docs") }}class="wrapper wide-content footer-links"{{ else }}class="wrapper footer-links"{{ end }}>
 		<div class="top-links">
 			<ul class="left-links">
 				<li><a href="{{ .Site.Params.twitter_url }}"><img src="/img/twitter.png" alt="Twitter logo" />Twitter</a></li>

--- a/themes/template/layouts/partials/header.html
+++ b/themes/template/layouts/partials/header.html
@@ -1,6 +1,6 @@
 {{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.docs_latest "") }}
 <header>
-	<div class="wrapper">
+	<div {{ if (eq .Page.Section "docs") }}class="wrapper wide-content"{{ else }}class="wrapper"{{ end }}>
 		<a href="{{ .Site.BaseURL }}"><img class="image" src="/img/cartographer-logo.svg" alt="Logo" /></a>
 		<ul class="desktop-links">
 			<li><a href="/" {{ if (eq .RelPermalink "/")  }}class="active"{{ end }}>Home</a></li>


### PR DESCRIPTION
[#610](https://github.com/vmware-tanzu/cartographer/issues/610)
Makes the docs header and footer as wide as the content (all other instances stay narrow even on large media)