### PR TITLE
Improve troublehsooting doc to include ResourcesHealthy condition

### DIFF
--- a/content/docs/v0.4.0/troubleshooting.md
+++ b/content/docs/v0.4.0/troubleshooting.md
@@ -75,8 +75,11 @@ Here's how the different `ResourceHealthy` condition statuses can come about, an
 | True    | OutputsAvailable   | Template author specified no rule, resource created and generates valid outputs.                                                                                                                                                    |
 | Unknown | OutputNotAvailable | Template author specified no rule, resource realized but no output available.                                                                                                                                                       |
 | Unknown | NoStampedObject    | Template author specified no rule, resource realized but not successfully submitted yet.                                                                                                                                            |
-| True    | AlwaysHealthy      | Template author specified no rule in a ClusterTemplate and resource realized and submitted.                                                                                                                                         |
-| True    | AlwaysHealthy      | Template author specified AlwaysHealthy rule. Resource is always considered healthy.                                                                                                                                                |
+| True    | AlwaysHealthy      | Template author specified no rule in a ClusterTemplate and resource realized and submitted.
+
+OR
+
+Template author specified AlwaysHealthy rule. Resource is always considered healthy.|
 | Unknown | XCondition         | Template author specified SingleConditionType X, and condition X on the actual resource is not found. Message will contain this detail.                                                                                             |
 | Unknown | XCondition         | Template author specified SingleConditionType X, and condition X on the actual resource is found but does not have a status of `True` or `False`. Message is copied forward from the actual resource.                               |
 | False   | XCondition         | Template author specified SingleConditionType X, and condition X on the actual resource is False. Message is copied forward from the actual resource.                                                                               |

--- a/content/docs/v0.4.0/troubleshooting.md
+++ b/content/docs/v0.4.0/troubleshooting.md
@@ -65,8 +65,7 @@ condition's status is determined by evaluating the `healthRule` for the template
 
 If this condition's status is `False` then one or more resources may not be healthy. If this condition's status is
 `Unknown` then the healthy state of one or more resources cannot be determined. In such situations, consult the
-individual `ResourceHealthy` (note that this is singular) condition listed in the owner's (`Workload`/`Deliverable`)
-`resources`.
+individual `Healthy` condition listed in the owner's `status.resources[*].conditions`
 
 Here's how the different `ResourceHealthy` condition statuses can come about, and what they mean:
 

--- a/content/docs/v0.4.0/troubleshooting.md
+++ b/content/docs/v0.4.0/troubleshooting.md
@@ -81,7 +81,10 @@ OR
 
 Template author specified AlwaysHealthy rule. Resource is always considered healthy.|
 | Unknown | XCondition         | Template author specified SingleConditionType X, and condition X on the actual resource is not found. Message will contain this detail.                                                                                             |
-| Unknown | XCondition         | Template author specified SingleConditionType X, and condition X on the actual resource is found but does not have a status of `True` or `False`. Message is copied forward from the actual resource.                               |
+
+OR
+
+Template author specified SingleConditionType X, and condition X on the actual resource is found but does not have a status of `True` or `False`. Message is copied forward from the actual resource.                               |
 | False   | XCondition         | Template author specified SingleConditionType X, and condition X on the actual resource is False. Message is copied forward from the actual resource.                                                                               |
 | True    | XCondition         | Template author specified SingleConditionType X, and condition X on the actual resource is True. Message is copied forward from the actual resource.                                                                                |
 | False   | MatchedCondition   | Template author specified MultiMatch and a specified unhealthy matchConditions rule matched. Message contains the status and message of the matchCondition in question.                                                             |


### PR DESCRIPTION
Documents known sub-conditions, with particular attention to `ResourcesHealthy`

Possible permutations of `ResourcesHealthy` `status` and `reasons` are also documented.

[Fixes #103]