### PR TITLE
Remove $ in front of CLI commands

### DIFF
--- a/content/docs/v0.5.0/tutorials/using-params.md
+++ b/content/docs/v0.5.0/tutorials/using-params.md
@@ -18,13 +18,13 @@ user guarantees are made about the script._
 Command to run from the Cartographer directory:
 
 ```shell
-$ ./hack/setup.sh cluster cartographer-latest
+./hack/setup.sh cluster cartographer-latest
 ```
 
 If you later wish to tear down this generated cluster, run
 
 ```shell
-$ ./hack/setup.sh teardown
+./hack/setup.sh teardown
 ```
 
 ## Scenario


### PR DESCRIPTION
Copy/paste into the terminal is not working (malformed command) because of $ sign in front of command. Suggestion is to remove "$" from all the commands, so readers can simply copy+paste commands into their terminal.