### PR TITLE
Remove $ in front of CLI commands

### DIFF
--- a/content/docs/v0.5.0/tutorials/runnable-in-a-supply-chain.md
+++ b/content/docs/v0.5.0/tutorials/runnable-in-a-supply-chain.md
@@ -22,13 +22,13 @@ end-to-end testing and while we rely on it working in that role, no user guarant
 Command to run from the Cartographer directory:
 
 ```shell
-$ ./hack/setup.sh cluster cartographer-latest example-dependencies
+./hack/setup.sh cluster cartographer-latest example-dependencies
 ```
 
 If you later wish to tear down this generated cluster, run
 
 ```shell
-$ ./hack/setup.sh teardown
+./hack/setup.sh teardown
 ```
 
 ## Scenario
@@ -364,7 +364,7 @@ Using [kubectl tree](https://github.com/ahmetb/kubectl-tree) we can see our work
 turn is parent to a pipeline-run.
 
 ```shell
-$ kubectl tree workload hello-again
+kubectl tree workload hello-again
 ```
 
 ```console


### PR DESCRIPTION
Copy/paste into the terminal is not working (malformed command) because of $ sign in front of command. Suggestion is to remove "$" from all the commands, so readers can simply copy+paste commands into their terminal.