### PR TITLE
Remove $ in front of CLI commands

### DIFF
--- a/content/docs/v0.5.0/tutorials/determining-health.md
+++ b/content/docs/v0.5.0/tutorials/determining-health.md
@@ -189,7 +189,7 @@ create a replicaset, which will create pods). What is different in this tutorial
 Let's observe the workload after giving a moment for the deployment's pods to come up.
 
 ```shell
-$ kubectl get -o yaml workload hello
+Remove $ in front of CLI commands get -o yaml workload hello
 ```
 
 First let's consider the `status.resources` field:
@@ -243,7 +243,7 @@ We'll see what feedback we get in the workload status.
 First, we'll check the workload just after deploying, inspecting the `status.resources`:
 
 ```shell
-$ kubectl get -o yaml workload typo
+kubectl get -o yaml workload typo
 ```
 
 ```yaml
@@ -265,7 +265,7 @@ From our discussion above, we know that the deployment will never reach a health
 it will continue to report that it is progressing but the expected pods are not available. We can observe this directly:
 
 ```shell
-$ kubectl get -o yaml deployment typo-deployment
+kubectl get -o yaml deployment typo-deployment
 ```
 
 ```yaml


### PR DESCRIPTION
Copy/paste into the terminal is not working (malformed command) because of $ sign in front of command. Suggestion is to remove "$" from all the commands, so readers can simply copy+paste commands into their terminal.